### PR TITLE
Add section on Intellectual Property

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The [CHARTER.md](https://github.com/ossf/project-template/blob/main/CHARTER.md) 
 
 In accordance with the [OpenSSF Charter (PDF)](https://charter.openssf.org/), work produced by this group is licensed as follows:
 
-[TODO: Select below the applicable license(s), delete those that don't apply, and update the LICENSE file accordingly. For specification development refer to the specific instructions on the [Community Specification Getting Started page](https://github.com/CommunitySpecification/1.0/blob/master/..Getting%20Started.md).
+[TODO: Select below the applicable license(s), delete those that don't apply, and update the LICENSE file accordingly. For specification development refer to the specific instructions on the [Community Specification Getting Started page](https://github.com/CommunitySpecification/1.0/blob/main/..Getting%20Started.md).
 
 Note that for source code, instead of Apache, you may choose to use the MIT License available at https://opensource.org/licenses/MIT. Otherwise, no other license than those listed here may be used without approval from the Governing Board.]
 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,21 @@ The [CHARTER.md](https://github.com/ossf/project-template/blob/main/CHARTER.md) 
 [OPTIONAL]
 *   Lead name 
 *   Co-Lead name
+
+#
+**Intellectual Property**
+
+In accordance with the [OpenSSF Charter (PDF)](https://charter.openssf.org/), work produced by this group is licensed as follows:
+
+[TODO: Select below the applicable license(s), delete those that don't apply, and update the LICENSE file accordingly. For specification development refer to the specific instructions on the [Community Specification Getting Started page](https://github.com/CommunitySpecification/1.0/blob/master/..Getting%20Started.md).
+
+Note that for source code, instead of Apache, you may choose to use the MIT License available at https://opensource.org/licenses/MIT. Otherwise, no other license than those listed here may be used without approval from the Governing Board.]
+
+1. Software source code
+* Apache License, Version 2.0, available at https://www.apache.org/licenses/LICENSE-2.0;
+2. Data
+* Any of the Community Data License Agreements, available at https://www.cdla.io;
+3. Specifications
+* Community Specification License, Version 1.0, available at https://github.com/CommunitySpecification/1.0
+4. All other Documentation
+* Creative Commons Attribution 4.0 International License, available at https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
This adds a section on IP with instructions on which license(s) to use in line with the charter.
This is in relation to the [TAC Issue #26 ](https://github.com/ossf/tac/issues/26)

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>